### PR TITLE
Remove onload param for ios

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,7 +31,6 @@
         <config-file target="config.xml" parent="/*">
             <feature name="LottieSplashScreen">
                 <param name="ios-package" value="LottieSplashScreen" />
-                <param name="onload" value="true" />
             </feature>
         </config-file>
 


### PR DESCRIPTION
Remove onload param for ios to prevent splashscreen from not being full screen : 
https://github.com/timbru31/cordova-plugin-lottie-splashscreen/issues/453